### PR TITLE
 #1: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS builder
+
+# Must be entire project because `prepare` script is run during `npm install` and requires all files.
+COPY . /app
+COPY tsconfig.json /tsconfig.json
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.npm npm i
+
+FROM node:22-alpine AS release
+
+WORKDIR /app
+
+COPY --from=builder /app/build /app/build
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+RUN npm i --frozen-lockfile --ignore-scripts
+
+ENTRYPOINT ["node", "build/index.js"]


### PR DESCRIPTION
   * Add Dockerfile to build and run Linear MCP server
   
---

## What
[ibraheem4/linear-mcp](https://github.com/ibraheem4/linear-mcp) uses `npx` as the runtime, which leads to possible installation issues with node.

## Why
Docker allows MCP server to run independently of platform installation and environment

## How
Add Dockerfile and push a Docker image for the [ibraheem4/linear-mcp](https://github.com/ibraheem4/linear-mcp)